### PR TITLE
Feat: setup of child view controllers

### DIFF
--- a/Job4U.xcodeproj/project.pbxproj
+++ b/Job4U.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9CB2B12A21ED201C003457F3 /* Job4UTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B12921ED201C003457F3 /* Job4UTests.m */; };
 		9CB2B13D21ED389E003457F3 /* LoginButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B13C21ED389E003457F3 /* LoginButton.m */; };
 		9CB2B14621ED5183003457F3 /* AppCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B14521ED5183003457F3 /* AppCoordinator.m */; };
+		9CB2B15421EE04AA003457F3 /* SignInViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B15321EE04AA003457F3 /* SignInViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,8 @@
 		9CB2B14321ED4ECD003457F3 /* Coordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Coordinator.h; sourceTree = "<group>"; };
 		9CB2B14421ED506B003457F3 /* AppCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppCoordinator.h; sourceTree = "<group>"; };
 		9CB2B14521ED5183003457F3 /* AppCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppCoordinator.m; sourceTree = "<group>"; };
+		9CB2B15321EE04AA003457F3 /* SignInViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SignInViewController.m; sourceTree = "<group>"; };
+		9CB2B15521EE04BD003457F3 /* SignInViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SignInViewController.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +119,8 @@
 			children = (
 				9CB2B11321ED2019003457F3 /* LoginViewController.h */,
 				9CB2B11421ED2019003457F3 /* LoginViewController.m */,
+				9CB2B15321EE04AA003457F3 /* SignInViewController.m */,
+				9CB2B15521EE04BD003457F3 /* SignInViewController.h */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -243,6 +248,7 @@
 				9CB2B13D21ED389E003457F3 /* LoginButton.m in Sources */,
 				9CB2B12021ED201B003457F3 /* main.m in Sources */,
 				9CB2B14621ED5183003457F3 /* AppCoordinator.m in Sources */,
+				9CB2B15421EE04AA003457F3 /* SignInViewController.m in Sources */,
 				9CB2B11221ED2019003457F3 /* AppDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Job4U.xcodeproj/project.pbxproj
+++ b/Job4U.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9CB2B13D21ED389E003457F3 /* LoginButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B13C21ED389E003457F3 /* LoginButton.m */; };
 		9CB2B14621ED5183003457F3 /* AppCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B14521ED5183003457F3 /* AppCoordinator.m */; };
 		9CB2B15421EE04AA003457F3 /* SignInViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B15321EE04AA003457F3 /* SignInViewController.m */; };
+		9CB2B15821EE0618003457F3 /* RegisterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9CB2B15721EE0618003457F3 /* RegisterViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,8 @@
 		9CB2B14521ED5183003457F3 /* AppCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppCoordinator.m; sourceTree = "<group>"; };
 		9CB2B15321EE04AA003457F3 /* SignInViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SignInViewController.m; sourceTree = "<group>"; };
 		9CB2B15521EE04BD003457F3 /* SignInViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SignInViewController.h; sourceTree = "<group>"; };
+		9CB2B15621EE0608003457F3 /* RegisterViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegisterViewController.h; sourceTree = "<group>"; };
+		9CB2B15721EE0618003457F3 /* RegisterViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RegisterViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +124,8 @@
 				9CB2B11421ED2019003457F3 /* LoginViewController.m */,
 				9CB2B15321EE04AA003457F3 /* SignInViewController.m */,
 				9CB2B15521EE04BD003457F3 /* SignInViewController.h */,
+				9CB2B15621EE0608003457F3 /* RegisterViewController.h */,
+				9CB2B15721EE0618003457F3 /* RegisterViewController.m */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -248,6 +253,7 @@
 				9CB2B13D21ED389E003457F3 /* LoginButton.m in Sources */,
 				9CB2B12021ED201B003457F3 /* main.m in Sources */,
 				9CB2B14621ED5183003457F3 /* AppCoordinator.m in Sources */,
+				9CB2B15821EE0618003457F3 /* RegisterViewController.m in Sources */,
 				9CB2B15421EE04AA003457F3 /* SignInViewController.m in Sources */,
 				9CB2B11221ED2019003457F3 /* AppDelegate.m in Sources */,
 			);

--- a/Job4U/Base.lproj/Main.storyboard
+++ b/Job4U/Base.lproj/Main.storyboard
@@ -36,10 +36,16 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5jS-UX-Lh2" userLabel="LoginButton">
                                                 <rect key="frame" x="168.5" y="50" width="38" height="30"/>
                                                 <state key="normal" title="Login"/>
+                                                <connections>
+                                                    <action selector="proceedToLogin:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JXP-z5-1RC"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fBd-Iq-HFO" userLabel="RegisterButton">
                                                 <rect key="frame" x="159" y="120" width="57" height="30"/>
                                                 <state key="normal" title="Register"/>
+                                                <connections>
+                                                    <action selector="proceedToRegister:" destination="BYZ-38-t0r" eventType="touchUpInside" id="2z0-vC-BKK"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Job4U/Login/LoginViewController.h
+++ b/Job4U/Login/LoginViewController.h
@@ -11,5 +11,6 @@
 @interface LoginViewController : UIViewController
 
 
+
 @end
 

--- a/Job4U/Login/LoginViewController.m
+++ b/Job4U/Login/LoginViewController.m
@@ -10,6 +10,8 @@
 
 @interface LoginViewController ()
 
+@property (nonatomic, strong) UIViewController *childViewController;
+
 @end
 
 @implementation LoginViewController
@@ -17,6 +19,12 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (IBAction)proceedToLogin:(id)sender {
+}
+
+- (IBAction)proceedToRegister:(id)sender {
 }
 
 

--- a/Job4U/Login/LoginViewController.m
+++ b/Job4U/Login/LoginViewController.m
@@ -7,6 +7,8 @@
 //
 
 #import "LoginViewController.h"
+#import "SignInViewController.h"
+#import "RegisterViewController.h"
 
 @interface LoginViewController ()
 
@@ -18,14 +20,23 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view, typically from a nib.
 }
 
 - (IBAction)proceedToLogin:(id)sender {
+    UIViewController *viewController = [[SignInViewController alloc] init];
+    [self displayChildViewController: viewController];
 }
 
 - (IBAction)proceedToRegister:(id)sender {
+    UIViewController *viewController = [[RegisterViewController alloc] init];
+    [self displayChildViewController:viewController];
 }
 
+- (void)displayChildViewController:(UIViewController*)viewController {
+    [self addChildViewController:viewController];
+    viewController.view.frame = self.view.frame;
+    [self.view addSubview:viewController.view];
+    [viewController didMoveToParentViewController:self];
+}
 
 @end

--- a/Job4U/Login/RegisterViewController.h
+++ b/Job4U/Login/RegisterViewController.h
@@ -1,0 +1,13 @@
+//
+//  RegisterViewController.h
+//  Job4U
+//
+//  Created by Matthew Dovey on 15/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface RegisterViewController : UIViewController
+
+@end

--- a/Job4U/Login/RegisterViewController.m
+++ b/Job4U/Login/RegisterViewController.m
@@ -1,0 +1,23 @@
+//
+//  RegisterViewController.m
+//  Job4U
+//
+//  Created by Matthew Dovey on 15/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "RegisterViewController.h"
+
+@interface RegisterViewController ()
+
+@end
+
+@implementation RegisterViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+}
+
+@end

--- a/Job4U/Login/RegisterViewController.m
+++ b/Job4U/Login/RegisterViewController.m
@@ -22,7 +22,7 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    self.view.backgroundColor = [UIColor redColor];
+    self.view.backgroundColor = [UIColor greenColor];
 }
 
 @end

--- a/Job4U/Login/RegisterViewController.m
+++ b/Job4U/Login/RegisterViewController.m
@@ -20,4 +20,9 @@
     [super viewDidLoad];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    self.view.backgroundColor = [UIColor redColor];
+}
+
 @end

--- a/Job4U/Login/SignInViewController.h
+++ b/Job4U/Login/SignInViewController.h
@@ -1,0 +1,13 @@
+//
+//  SignInViewController.h
+//  Job4U
+//
+//  Created by Matthew Dovey on 15/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+#ifndef SignInViewController_h
+#define SignInViewController_h
+
+
+#endif /* SignInViewController_h */

--- a/Job4U/Login/SignInViewController.h
+++ b/Job4U/Login/SignInViewController.h
@@ -6,8 +6,8 @@
 //  Copyright © 2019 Matthew Dovey. All rights reserved.
 //
 
-#ifndef SignInViewController_h
-#define SignInViewController_h
+#import <UIKit/UIKit.h>
 
+@interface SignInViewController : UIViewController
 
-#endif /* SignInViewController_h */
+@end

--- a/Job4U/Login/SignInViewController.m
+++ b/Job4U/Login/SignInViewController.m
@@ -7,3 +7,17 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "SignInViewController.h"
+
+@interface SignInViewController ()
+
+@end
+
+@implementation SignInViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+}
+
+@end

--- a/Job4U/Login/SignInViewController.m
+++ b/Job4U/Login/SignInViewController.m
@@ -20,4 +20,9 @@
     [super viewDidLoad];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    self.view.backgroundColor = [UIColor redColor];
+}
+
 @end

--- a/Job4U/Login/SignInViewController.m
+++ b/Job4U/Login/SignInViewController.m
@@ -1,0 +1,9 @@
+//
+//  SignInViewController.m
+//  Job4U
+//
+//  Created by Matthew Dovey on 15/01/2019.
+//  Copyright © 2019 Matthew Dovey. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This in a iOS app that allows companies and individuals looking to advertise or 
 
 * MVVM (Model-View-Viewmodel)
 * Coordinator Pattern
+* Child View Controllers
 
 ## Built With
 


### PR DESCRIPTION
This PR sets up the ability to present child view controllers so that the sign in and register screen can be presented over the initial screen when the buttons are used. At the moment the sign in and register screens are empty, but have been assigned background colours to separate them and make it easier to distinguish between the two.