### PR TITLE
proj: setup of gitignore and addition of various file types and carthage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Project Specific
+
+### Carthage ###
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+## Various Settings
+xcuserdata/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Carthage/Checkouts/SnapKit"]
+	path = Carthage/Checkouts/SnapKit
+	url = https://github.com/SnapKit/SnapKit.git


### PR DESCRIPTION
This PR adds a .gitignore file to the project so that various files can be set as ignored and the carthage build folder does not get added to the repo.