### PR TITLE
Docs: removal of snapkit from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Items marked with the (Future) tag are features and patterns that I plan to use 
 
 * Carthage Dependency Manager
 * Firebase Analytics / Crashlytics (Future)
-* Snapkit
 
 ## Contributing
 


### PR DESCRIPTION
This PR removes snapkit from the README built with section due to lack of objective c support.