### PR TITLE
Docs: Update of README file to present the use of MVVM+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Items marked with the (Future) tag are features and patterns that I plan to use 
 
 ## Architectural Patterns Used
 
-* MVVM (Model-View-Viewmodel)
+* MVVM+C (Model-View-Viewmodel + Coordinator)
 * Coordinator Pattern
 * Built without storyboard
 


### PR DESCRIPTION
This PR updates the architecture pattern used throughout the app to be MVVM+C.